### PR TITLE
Update dependencies for Pico 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PicoAuth provides authentication and authorization for flat file CMS Pico.",
     "keywords": ["authentication","authorization","flat-file","Pico","oauth2","sso","plugin","users","picocms"],
     "license": "MIT",
-    "minimum-stability": "beta",
+    "minimum-stability": "alpha",
     "authors": [
         {
             "name": "Pavel Tuma",
@@ -18,15 +18,14 @@
         "source": "https://github.com/picoauth/picoauth"
     },
     "require": {
-        "php": "^5.6.0 || ^7.0 || ^8.0",
-        "picocms/pico": "~2.0",
+        "php": "^7.2 || ^8.0",
+        "picocms/pico": "~3.0",
         "psr/log": "^1.0.1",
         "psr/simple-cache": "^1.0",
-        "symfony/yaml": "^2.8",
+        "symfony/yaml": "^5.4.3",
         "symfony/http-foundation": "^2.8",
-        "league/container": "^2.4",
-        "league/oauth2-client": "^2.3",
-        "paragonie/random_compat": "^2.0"
+        "league/container": "^4.2",
+        "league/oauth2-client": "^2.3"
     },
     "require-dev" : {
         "phpdocumentor/phpdocumentor": "^2.9",

--- a/src/PicoAuthPlugin.php
+++ b/src/PicoAuthPlugin.php
@@ -748,10 +748,10 @@ class PicoAuthPlugin implements PicoAuthInterface
         }
 
         // Additional container entries
-        $this->container->share('configDir', new \League\Container\Argument\RawArgument($configDir));
-        $this->container->share('PicoAuth', $this);
+        $this->container->addShared('configDir', new \League\Container\Argument\Literal\StringArgument($configDir));
+        $this->container->addShared('PicoAuth', $this);
         if (!$this->config["rateLimit"]) {
-            $this->container->share('RateLimit', \PicoAuth\Security\RateLimiting\NullRateLimit::class);
+            $this->container->addShared('RateLimit', \PicoAuth\Security\RateLimiting\NullRateLimit::class);
         }
     }
 

--- a/src/PicoAuthPlugin.php
+++ b/src/PicoAuthPlugin.php
@@ -318,7 +318,7 @@ class PicoAuthPlugin implements PicoAuthInterface
 
         $this_instance = $this;
         $twig->addFunction(
-            new \Twig_SimpleFunction(
+            new \Twig\TwigFunction(
                 'csrf_token',
                 function ($action = null) use (&$this_instance) {
                     return $this_instance->csrf->getToken($action);
@@ -327,7 +327,7 @@ class PicoAuthPlugin implements PicoAuthInterface
             )
         );
         $twig->addFunction(
-            new \Twig_SimpleFunction(
+            new \Twig\TwigFunction(
                 'csrf_field',
                 function ($action = null) use (&$this_instance) {
                     return '<input type="hidden" name="csrf_token" value="'

--- a/src/container.php
+++ b/src/container.php
@@ -9,13 +9,14 @@
  * instead of the default one.
  */
 
-use League\Container\Argument\RawArgument;
+use League\Container\Argument\Literal\StringArgument;
+use League\Container\Argument\Literal\ArrayArgument;
 use League\Container\Container;
 
-$container = new Container;
+$container = new League\Container\Container();
 
 // Version of this file, so PicoAuth can detect possibly outdated definition
-$container->share('Version', new RawArgument(10000));
+$container->addShared('Version', new StringArgument(10000));
 
 
 // ****************** Configuration cache setup ********************************
@@ -23,37 +24,37 @@ $container->share('Version', new RawArgument(10000));
 // Any implementation of Psr\SimpleCache\CacheInterface
 // e.g. from package cache/cache: $pool = new ApcuCachePool();
 $pool = 'PicoAuth\Cache\NullCache';
-$container->share('cache', $pool);
+$container->addShared('cache', $pool);
 
 // ****************** Logger setup *********************************************
 
 // Any implementation of \Psr\Log\LoggerInterface
 // e.g. $log = new \Monolog\Logger('name');
 $log = 'Psr\Log\NullLogger';
-$container->share('logger', $log);
+$container->addShared('logger', $log);
 
 // ****************** Mail setup ***********************************************
 
 // Any implementation of PicoAuth\Mail\MailerInterface
 //include 'Mailer.php';
-//$container->share('mailer','PicoAuth\Mail\Mailer');
+//$container->addShared('mailer','PicoAuth\Mail\Mailer');
 
 // ****************** Password policy setup ************************************
 
 // Specify constraints of the default policy
 // Or provide an alternative implementation of PicoAuth\Security\Password\Policy\PasswordPolicyInterface
 
-$container->share('PasswordPolicy', 'PicoAuth\Security\Password\Policy\PasswordPolicy')
-    ->withMethodCall('minLength', [new RawArgument(8)]);
+$container->addShared('PasswordPolicy', 'PicoAuth\Security\Password\Policy\PasswordPolicy')
+    ->addMethodCall('minLength', [new StringArgument(8)]);
 
 // ****************** Session management configuration *************************
 
 // PicoAuth default session driver
-$container->share('session', 'PicoAuth\Session\SymfonySession')
-    ->withArgument('session.storage');
+$container->addShared('session', 'PicoAuth\Session\SymfonySession')
+    ->addArgument('session.storage');
 
-$container->share('session.storage', 'Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage')
-    ->withArgument(new RawArgument(array(
+$container->addShared('session.storage', 'Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage')
+    ->addArgument(new ArrayArgument(array(
         //"cookie_secure" => "0",       // Set to "1" if using HTTPS
         "cookie_lifetime" => "0",       // Until user closes the browser
         "gc_maxlifetime" => "7200",     // Activity timeout 2hrs
@@ -64,48 +65,48 @@ $container->share('session.storage', 'Symfony\Component\HttpFoundation\Session\S
 // *****************************************************************************
 
 // PicoAuth modules
-$container->share('LocalAuth', 'PicoAuth\Module\Authentication\LocalAuth\LocalAuth')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('LocalAuth.storage')
-    ->withArgument('RateLimit');
+$container->addShared('LocalAuth', 'PicoAuth\Module\Authentication\LocalAuth\LocalAuth')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('LocalAuth.storage')
+    ->addArgument('RateLimit');
 
-$container->share('OAuth', 'PicoAuth\Module\Authentication\OAuth')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('OAuth.storage')
-    ->withMethodCall('setLogger', ['logger']);
+$container->addShared('OAuth', 'PicoAuth\Module\Authentication\OAuth')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('OAuth.storage')
+    ->addMethodCall('setLogger', ['logger']);
 
-$container->share('PageACL', 'PicoAuth\Module\Authorization\PageACL')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('PageACL.storage');
+$container->addShared('PageACL', 'PicoAuth\Module\Authorization\PageACL')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('PageACL.storage');
 
-$container->share('PageLock', 'PicoAuth\Module\Authorization\PageLock')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('PageLock.storage')
-    ->withArgument('RateLimit');
+$container->addShared('PageLock', 'PicoAuth\Module\Authorization\PageLock')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('PageLock.storage')
+    ->addArgument('RateLimit');
 
-$container->share('Installer', 'PicoAuth\Module\Generic\Installer')
-    ->withArgument('PicoAuth');
+$container->addShared('Installer', 'PicoAuth\Module\Generic\Installer')
+    ->addArgument('PicoAuth');
 
 // Storage
-$container->share('LocalAuth.storage', 'PicoAuth\Storage\LocalAuthFileStorage')
-    ->withArgument('configDir')
-    ->withArgument('cache');
-$container->share('OAuth.storage', 'PicoAuth\Storage\OAuthFileStorage')
-    ->withArgument('configDir')
-    ->withArgument('cache');
-$container->share('PageACL.storage', 'PicoAuth\Storage\PageACLFileStorage')
-    ->withArgument('configDir')
-    ->withArgument('cache');
-$container->share('PageLock.storage', 'PicoAuth\Storage\PageLockFileStorage')
-    ->withArgument('configDir')
-    ->withArgument('cache');
-$container->share('RateLimit.storage', 'PicoAuth\Storage\RateLimitFileStorage')
-    ->withArgument('configDir')
-    ->withArgument('cache');
+$container->addShared('LocalAuth.storage', 'PicoAuth\Storage\LocalAuthFileStorage')
+    ->addArgument('configDir')
+    ->addArgument('cache');
+$container->addShared('OAuth.storage', 'PicoAuth\Storage\OAuthFileStorage')
+    ->addArgument('configDir')
+    ->addArgument('cache');
+$container->addShared('PageACL.storage', 'PicoAuth\Storage\PageACLFileStorage')
+    ->addArgument('configDir')
+    ->addArgument('cache');
+$container->addShared('PageLock.storage', 'PicoAuth\Storage\PageLockFileStorage')
+    ->addArgument('configDir')
+    ->addArgument('cache');
+$container->addShared('RateLimit.storage', 'PicoAuth\Storage\RateLimitFileStorage')
+    ->addArgument('configDir')
+    ->addArgument('cache');
 
 // Password hashing options
 $container->add('bcrypt', 'PicoAuth\Security\Password\Encoder\BCrypt');
@@ -113,29 +114,29 @@ $container->add('argon2i', 'PicoAuth\Security\Password\Encoder\Argon2i');
 $container->add('plain', 'PicoAuth\Security\Password\Encoder\Plaintext');
 
 // Rate limiting
-$container->share('RateLimit', 'PicoAuth\Security\RateLimiting\RateLimit')
-    ->withArgument('RateLimit.storage')
-    ->withMethodCall('setLogger', ['logger']);
+$container->addShared('RateLimit', 'PicoAuth\Security\RateLimiting\RateLimit')
+    ->addArgument('RateLimit.storage')
+    ->addMethodCall('setLogger', ['logger']);
 
 // LocalAuth extensions
-$container->share('PasswordReset', 'PicoAuth\Module\Authentication\LocalAuth\PasswordReset')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('LocalAuth.storage')
-    ->withArgument('RateLimit')
-//  ->withMethodCall('setMailer',['mailer'])
-    ->withMethodCall('setLogger', ['logger']);
+$container->addShared('PasswordReset', 'PicoAuth\Module\Authentication\LocalAuth\PasswordReset')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('LocalAuth.storage')
+    ->addArgument('RateLimit')
+//  ->addMethodCall('setMailer',['mailer'])
+    ->addMethodCall('setLogger', ['logger']);
 
-$container->share('Registration', 'PicoAuth\Module\Authentication\LocalAuth\Registration')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('LocalAuth.storage')
-    ->withArgument('RateLimit')
-    ->withMethodCall('setLogger', ['logger']);
+$container->addShared('Registration', 'PicoAuth\Module\Authentication\LocalAuth\Registration')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('LocalAuth.storage')
+    ->addArgument('RateLimit')
+    ->addMethodCall('setLogger', ['logger']);
 
-$container->share('EditAccount', 'PicoAuth\Module\Authentication\LocalAuth\EditAccount')
-    ->withArgument('PicoAuth')
-    ->withArgument('session')
-    ->withArgument('LocalAuth.storage');
+$container->addShared('EditAccount', 'PicoAuth\Module\Authentication\LocalAuth\EditAccount')
+    ->addArgument('PicoAuth')
+    ->addArgument('session')
+    ->addArgument('LocalAuth.storage');
 
 return $container;


### PR DESCRIPTION
Please have a look at this PR. 
I think it should become a new Release due to breaking Changes in the Twig Dependency.
Since neither Pico 3 nor other dependencies support PHP 5 anymore I changed the Requirement of PHP and deleted paragonie/random_compat.
Maybe symfony/http-foundation should be updated too, but I didn't dare to do so ;)
Since I got no idea how to write tests, I haven't touched anything over there.
I hope it helps and closes #8 
